### PR TITLE
On Socket Reconnect, the OnDone() was firing on the old socket. This …

### DIFF
--- a/lib/datasources/socket/socket.dart
+++ b/lib/datasources/socket/socket.dart
@@ -97,7 +97,11 @@ class Socket
         lastMessage = null;
 
         // close the old socket
-        if (_socket != null) await _socket!.sink.close();
+        if (_socket != null)
+        {
+          final subscription = _socket!.stream.listen((_) => null, onDone: () => null, onError: () => null);
+          await _socket!.sink.close();
+        }
 
         // connect
         connected = false;


### PR DESCRIPTION
…fix removed the OnData(), onDone() and onError() listeners before closing the sink.