### PR TITLE
Added tags to option for typeahead select

### DIFF
--- a/lib/widgets/option/option_model.dart
+++ b/lib/widgets/option/option_model.dart
@@ -37,12 +37,29 @@ class OptionModel extends WidgetModel
     return null;
   }
 
-  OptionModel(WidgetModel? parent, String? id, {dynamic data, dynamic labelValue, IViewableWidget? label, dynamic value}) : super(parent, id, scope: Scope(id))
+  //////////
+  /* tags */
+  //////////
+  StringObservable? _tags;
+  set tags(dynamic v) {
+    if (_tags != null) {
+      _tags!.set(v);
+    } else if (v != null) {
+      _tags = StringObservable(Binding.toKey(id, 'tags'), v, scope: scope, listener: onPropertyChange);
+    }
+  }
+
+  String? get tags {
+    return _tags?.get();
+  }
+
+  OptionModel(WidgetModel? parent, String? id, {dynamic data, dynamic labelValue, IViewableWidget? label, dynamic value, dynamic tags}) : super(parent, id, scope: Scope(id))
   {
     this.data = data;
     if (label != null) this.label = label;
     if (labelValue != null) this.labelValue = labelValue;
     if (value != null) this.value = value;
+    if (tags != null) this.tags = tags;
   }
 
   static OptionModel? fromXml(WidgetModel? parent, XmlElement? xml, {dynamic data})
@@ -106,5 +123,7 @@ class OptionModel extends WidgetModel
     }
     else this.value = value;
     labelValue = label;
+
+    tags = Xml.get(node: xml, tag: 'tags');
   }
 }

--- a/lib/widgets/select/select_model.dart
+++ b/lib/widgets/select/select_model.dart
@@ -275,24 +275,24 @@ class SelectModel extends FormFieldModel implements IFormField, IViewableWidget
     // instantiate busy observable
     busy = false;
 
-    if (mandatory    != null)  this.mandatory   = mandatory;
-    if (bordercolor  != null)  this.bordercolor = bordercolor;
-    if (color        != null)  this.color       = color;
-    if (radius       != null)  this.radius      = radius;
-    if (borderwidth  != null)  this.borderwidth = borderwidth;
-    if (border       != null)  this.border      = border;
-    if (hint         != null)  this.hint        = hint;
-    if (editable     != null)  this.editable    = editable;
-    if (enabled      != null)  this.enabled     = enabled;
-    if (inputenabled != null) this.inputenabled = inputenabled;
-    if (value        != null) this.value        = value;
-    if (defaultValue != null) this.defaultValue = defaultValue;
-    if (width        != null) this.width        = width;
-    if (onchange     != null) this.onchange     = onchange;
-    if (post         != null) this.post         = post;
-    if (typeahead    != null) this.typeahead    = typeahead;
-    if (matchtype    != null) this.matchtype    = matchtype;
-    if (label    != null) this.label    = label;
+    if (mandatory     != null)  this.mandatory    = mandatory;
+    if (bordercolor   != null)  this.bordercolor  = bordercolor;
+    if (color         != null)  this.color        = color;
+    if (radius        != null)  this.radius       = radius;
+    if (borderwidth   != null)  this.borderwidth  = borderwidth;
+    if (border        != null)  this.border       = border;
+    if (hint          != null)  this.hint         = hint;
+    if (editable      != null)  this.editable     = editable;
+    if (enabled       != null)  this.enabled      = enabled;
+    if (inputenabled  != null) this.inputenabled  = inputenabled;
+    if (value         != null) this.value         = value;
+    if (defaultValue  != null) this.defaultValue  = defaultValue;
+    if (width         != null) this.width         = width;
+    if (onchange      != null) this.onchange      = onchange;
+    if (post          != null) this.post          = post;
+    if (typeahead     != null) this.typeahead     = typeahead;
+    if (matchtype     != null) this.matchtype     = matchtype;
+    if (label         != null) this.label         = label;
 
     this.alarming = false;
     this.dirty    = false;
@@ -338,15 +338,14 @@ class SelectModel extends FormFieldModel implements IFormField, IViewableWidget
     this.options.clear();
     List<OptionModel> options = findChildrenOfExactType(OptionModel).cast<OptionModel>();
 
-      // set prototype
-      if ((!S.isNullOrEmpty(datasource)) && (options.isNotEmpty))
-      {
-        prototype = S.toPrototype(options[0].element.toString());
-        options.removeAt(0);
-      }
-      // build options
-      options.forEach((option) => this.options.add(option));
-
+    // set prototype
+    if ((!S.isNullOrEmpty(datasource)) && (options.isNotEmpty))
+    {
+      prototype = S.toPrototype(options[0].element.toString());
+      options.removeAt(0);
+    }
+    // build options
+    options.forEach((option) => this.options.add(option));
 
     // Set selected option
     setData();
@@ -401,10 +400,9 @@ class SelectModel extends FormFieldModel implements IFormField, IViewableWidget
   }
 
   @override
-  onDataSourceException(IDataSource source, Exception exception)
-  {
+  onDataSourceException(IDataSource source, Exception exception) {
     // Clear the List - Olajos 2021-09-04
-    onDataSourceSuccess(null,null);
+    onDataSourceSuccess(null, null);
   }
 
   void setData()

--- a/lib/widgets/select/select_view.dart
+++ b/lib/widgets/select/select_view.dart
@@ -346,29 +346,42 @@ return LayoutBuilder(builder: builder);
     if (position != null) widget.model.offset = position;
   }
 
-  bool suggestion(OptionModel m, String pat) {
-    String? s = (m.label is TextModel) ? (m.label as TextModel).value ?? null : null ?? '' + _extractText(m)!;
-    if (s == null) return false;
-
-    else if (S.isNullOrEmpty(widget.model.matchtype) || widget.model.matchtype!.toLowerCase() == 'contains') {
-      return s.toLowerCase().contains(pat.toLowerCase());
-    }
-    else if (widget.model.matchtype!.toLowerCase() == 'startswith') {
-      return s.toLowerCase().startsWith(pat.toLowerCase());
-    }
-    else if (widget.model.matchtype!.toLowerCase() == 'endswith') {
-      return s.toLowerCase().endsWith(pat.toLowerCase());
-    }
-    return true;
-  }
-
   Future<List<OptionModel>> getSuggestions(String pattern) async
   {
-    var suggestions = widget.model.options.where((model) => suggestion(model, pattern));
-    var others = widget.model.options.where((model) => !suggestion(model, pattern));
-    var results = suggestions.toList();
+    Iterable<OptionModel> suggestions = widget.model.options.where((model) => suggestion(model, pattern));
+    Iterable<OptionModel> others = widget.model.options.where((model) => !suggestion(model, pattern));
+    List<OptionModel> results = suggestions.toList();
     if (others.isNotEmpty) results.addAll(others);
     return results;
+  }
+
+
+  bool suggestion(OptionModel m, String pat) {
+    pat = pat.toLowerCase();
+    if (m.tags != null && m.tags!.length > 0) {
+      List<String?> s = m.tags!.split(',');
+      return s.any((tag) => match(tag!.trim().toLowerCase(), pat));
+    }
+    else {
+      String? str = (m.label is TextModel) ? (m.label as TextModel).value ?? null : null ?? '' + _extractText(m)!;
+      return str == null ? false : match(str, pat);
+    }
+
+  }
+
+  bool match(String tag, String pat) {
+    if (tag == '' || tag == 'null')
+      return false;
+    else if (S.isNullOrEmpty(widget.model.matchtype) || widget.model.matchtype!.toLowerCase() == 'contains') {
+      return tag.contains(pat.toLowerCase());
+    }
+    else if (widget.model.matchtype!.toLowerCase() == 'startswith') {
+      return tag.startsWith(pat.toLowerCase());
+    }
+    else if (widget.model.matchtype!.toLowerCase() == 'endswith') {
+      return tag.endsWith(pat.toLowerCase());
+    }
+    return false;
   }
 
   static String? _extractText(OptionModel? model)
@@ -431,8 +444,8 @@ return LayoutBuilder(builder: builder);
   Future<bool> _commit() async
   {
     controller.text = controller.text.trim();
-    //if the value does not match the option value, clear only when input is disabled.
-    if(controller.text != widget.model.value && !widget.model.inputenabled && widget.model.typeahead) controller.text = widget.model.value;
+    // if the value does not match the option value, clear only when input is disabled.
+    if (controller.text != widget.model.value && !widget.model.inputenabled && widget.model.typeahead) controller.text = widget.model.value;
 
   return true;
   }


### PR DESCRIPTION
`<OPTION>`s can have a tag parameter with multiple tags separated by commas. Typeahead `<SELECT>`s will use the tag attribute to check each tag for a match, if no tags are provided the typeahead pattern will be matched to the label as before.