### PR TITLE
Updated the Xml2Json package. This fixed an issue where sub-elements …

### DIFF
--- a/assets/applications/fmlpad/fmlpad.xml
+++ b/assets/applications/fmlpad/fmlpad.xml
@@ -191,85 +191,11 @@
 
             <!-- examples -->
             <GET id="db1" url="{examples}" onsuccess="editor.set({this.response})"/>
-            <SELECT id="examples" bordercolor="#1E2835" value="1">
-
-                <OPTION label='templates' value="1"/>
-
-                <!-- widgets -->
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="speed" size="16" color="green"/><PAD left="10"/><TEXT value="<SLIDER/>"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/slider-example1.xml</value>
+            <GET id="db2" url="https://fml.dev/fmlpad/examples.xml" root="EXAMPLES.EXAMPLE"/>
+            <SELECT id="examples" bordercolor="#1E2835" value="1" data="db2">
+                <OPTION value="{data.url}">
+                    <label><ROW expand="false" valign="center"><ICON icon="{data.icon}" size="16" color="{data.color}"/><PAD left="10"/><TEXT value="{data.title}"/></ROW></label>
                 </OPTION>
-
-                <!-- charts -->
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="pie_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Pie Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example1.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="multiline_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Line Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example2.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="bar_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Bar Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example3.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="add_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Combo Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example4.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="stacked_bar_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Grouped Bar Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example5.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="stacked_bar_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Stacked Bar Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example6.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="stacked_line_chart" size="16" color="yellow"/><PAD left="10"/><TEXT value="Grouped/Stacked Bar Chart"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/chart-example7.xml</value>
-                </OPTION>
-
-                <!-- maps -->
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="place_outlined" size="16" color="white"/><PAD left="10"/><TEXT value="Satellite Map"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/map-example1.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="place_outlined" size="16" color="white"/><PAD left="10"/><TEXT value="Vector Map"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/map-example2.xml</value>
-                </OPTION>
-
-                <!-- image transforms -->
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="image_outlined" size="16" color="green"/><PAD left="10"/><TEXT value="Image Crop"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/image-transforms-example1.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="image_outlined" size="16" color="green"/><PAD left="10"/><TEXT value="Image Flip"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/image-transforms-example2.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="image_outlined" size="16" color="green"/><PAD left="10"/><TEXT value="Image to Gray Scale"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/image-transforms-example3.xml</value>
-                </OPTION>
-
-                <OPTION>
-                    <label><ROW expand="false" valign="center"><ICON icon="image_outlined" size="16" color="green"/><PAD left="10"/><TEXT value="Image Resizing"/></ROW></label>
-                    <value>https://fml.dev/assets/templates/examples/image-transforms-example4.xml</value>
-                </OPTION>
-
-
             </SELECT>
 
             <!-- realtime slider -->

--- a/lib/data/data.dart
+++ b/lib/data/data.dart
@@ -319,17 +319,21 @@ class Data with ListMixin<dynamic>
         {
           if (data is Map)
           {
-            if (!data.containsKey(property.name))
+            // attributes are named with an underscore
+            // to make it easier for the user, we first look for the
+            // property by name, then if not found, look for it by _name
+            var name  = property.name;
+            var _name = "_$name";
+            if (!data.containsKey(name) && (!data.containsKey(_name)))
             {
               data = null;
               break;
             }
-            data = data[property.name];
+            data = data.containsKey(name) ? data[name] : data[_name];
 
             if ((data is Map)  && (property.offset > 0)) data = null;
             if ((data is List) && (property.offset > data.length)) data = null;
             if ((data is List) && (property.offset < data.length) && (property.offset >= 0))  data = data[property.offset];
-
           }
 
           else if (data is List)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -224,8 +224,8 @@ dependencies:
   xml: 6.1.0
   # MIT
 
-  # Updated 2022/06/17
-  xml2json: 5.3.3
+  # Updated 2023/02/06
+  xml2json: 5.3.6
   # MIT
 
   # Updated 2021/09/23


### PR DESCRIPTION
…with no body elements themselves were not being converted properly. Modified Data.readValue() to first look for the item by name, then look for it using the underscore name value "_name". This makes it convenient for the user to reference attributes by name in data binding rather than having to use _name (default naming for attributes using Parker Converter in Xml2Json)