### PR TITLE
Camera Error Cases

### DIFF
--- a/lib/widgets/camera/camera_view.dart
+++ b/lib/widgets/camera/camera_view.dart
@@ -214,21 +214,27 @@ class CameraViewState extends State<CameraView>
             switch (e.code) {
               case 'CameraAccessDenied':
               // Thrown when user denies the camera access permission.
+                widget.model.onFail(Data(), message: "User denied Camera/Microphone access permissions");
                 break;
               case 'CameraAccessDeniedWithoutPrompt':
               // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Camera in order to enable camera access.
+                widget.model.onFail(Data(), message: "User previously denied Camera access permissions, to change this go to Settings > Privacy > Camera");
                 break;
               case 'CameraAccessRestricted':
               // iOS only for now. Thrown when camera access is restricted and users cannot grant permission (parental control).
+                widget.model.onFail(Data(), message: "Parental control denied Camera access permissions");
                 break;
               case 'AudioAccessDenied':
               // Thrown when user denies the audio access permission.
+                widget.model.onFail(Data(), message: "User denied Microphone access permissions");
                 break;
               case 'AudioAccessDeniedWithoutPrompt':
               // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Microphone in order to enable audio access.
+                widget.model.onFail(Data(), message: "User previously denied Microphone access permissions, to change this go to Settings > Privacy > Microphone");
                 break;
               case 'AudioAccessRestricted':
               // iOS only for now. Thrown when audio access is restricted and users cannot grant permission (parental control).
+                widget.model.onFail(Data(), message: "Parental control denied Microphone access permissions");
                 break;
               default:
               // Handle other errors here.

--- a/lib/widgets/camera/camera_view.dart
+++ b/lib/widgets/camera/camera_view.dart
@@ -256,6 +256,7 @@ class CameraViewState extends State<CameraView>
                 break;
               default:
               // Handle other errors here.
+                widget.model.onFail(Data(), message: "Camera Initialization Error");
                 break;
             }
           }

--- a/lib/widgets/camera/camera_view.dart
+++ b/lib/widgets/camera/camera_view.dart
@@ -206,9 +206,40 @@ class CameraViewState extends State<CameraView>
         controller = CameraController(camera, resolution, imageFormatGroup: format, enableAudio: false);
 
         // initialize the controller
-        await controller!.initialize();
+        try {
+          await controller!.initialize();
+          if (!mounted) return;
+        } catch(e) {
+          if (e is CameraException) {
+            switch (e.code) {
+              case 'CameraAccessDenied':
+              // Thrown when user denies the camera access permission.
+                break;
+              case 'CameraAccessDeniedWithoutPrompt':
+              // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Camera in order to enable camera access.
+                break;
+              case 'CameraAccessRestricted':
+              // iOS only for now. Thrown when camera access is restricted and users cannot grant permission (parental control).
+                break;
+              case 'AudioAccessDenied':
+              // Thrown when user denies the audio access permission.
+                break;
+              case 'AudioAccessDeniedWithoutPrompt':
+              // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Microphone in order to enable audio access.
+                break;
+              case 'AudioAccessRestricted':
+              // iOS only for now. Thrown when audio access is restricted and users cannot grant permission (parental control).
+                break;
+              default:
+              // Handle other errors here.
+                break;
+            }
+          }
+          else {
+            Log().exception(e,  caller: 'camera.View');
+          }
+        }
 
-        if (!mounted) return;
         try {
           // min zoom
           _zoom = await controller!.getMinZoomLevel();

--- a/lib/widgets/camera/camera_view.dart
+++ b/lib/widgets/camera/camera_view.dart
@@ -229,28 +229,28 @@ class CameraViewState extends State<CameraView>
           if (!mounted) return;
         } catch(e) {
           if (e is CameraException) {
-            switch (e.code) {
-              case 'CameraAccessDenied':
+            switch (e.code.toLowerCase()) {
+              case 'cameraaccessdenied':
               // Thrown when user denies the camera access permission.
                 widget.model.onFail(Data(), message: "User denied Camera/Microphone access permissions");
                 break;
-              case 'CameraAccessDeniedWithoutPrompt':
+              case 'cameraaccessdeniedwithoutprompt':
               // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Camera in order to enable camera access.
                 widget.model.onFail(Data(), message: "User previously denied Camera access permissions, to change this go to Settings > Privacy > Camera");
                 break;
-              case 'CameraAccessRestricted':
+              case 'cameraaccessrestricted':
               // iOS only for now. Thrown when camera access is restricted and users cannot grant permission (parental control).
                 widget.model.onFail(Data(), message: "Parental control denied Camera access permissions");
                 break;
-              case 'AudioAccessDenied':
+              case 'audioaccessdenied':
               // Thrown when user denies the audio access permission.
                 widget.model.onFail(Data(), message: "User denied Microphone access permissions");
                 break;
-              case 'AudioAccessDeniedWithoutPrompt':
+              case 'audioaccessdeniedwithoutprompt':
               // iOS only for now. Thrown when user has previously denied the permission. iOS does not allow prompting alert dialog a second time. Users will have to go to Settings > Privacy > Microphone in order to enable audio access.
                 widget.model.onFail(Data(), message: "User previously denied Microphone access permissions, to change this go to Settings > Privacy > Microphone");
                 break;
-              case 'AudioAccessRestricted':
+              case 'audioaccessrestricted':
               // iOS only for now. Thrown when audio access is restricted and users cannot grant permission (parental control).
                 widget.model.onFail(Data(), message: "Parental control denied Microphone access permissions");
                 break;

--- a/lib/widgets/camera/camera_view.dart
+++ b/lib/widgets/camera/camera_view.dart
@@ -150,7 +150,25 @@ class CameraViewState extends State<CameraView>
       }
 
       // get cameras
-      if (cameras == null) cameras = await availableCameras();
+      try {
+        if (cameras == null) cameras = await availableCameras();
+      } catch(e) {
+        if (e is CameraException) {
+          switch (e.code.toLowerCase()) {
+            case 'permissiondenied':
+            // Thrown when user is not on a secure (https) connection.
+              widget.model.onFail(Data(), message: "Camera is only available over a secure (https) connection");
+              break;
+            default:
+            // Handle other errors here.
+              widget.model.onFail(Data(), message: "Unable to get any available Cameras");
+              break;
+          }
+        }
+        else {
+          Log().exception(e,  caller: 'camera.View');
+        }
+      }
       if ((cameras != null) && (cameras!.length > 0))
       {
         // set specified camera

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
   audioplayers: 0.20.1
   # MIT
 
-  # Updated 2023/01/04
-  camera: 0.10.1
+  # Updated 2023/02/21
+  camera: ^0.10.3
   # BSD-3-Clause
 
   # Updated 2023/02/07


### PR DESCRIPTION
Return errors on http (requires https)
Return errors on no available cameras
Return errors on missing/denied permissions