### PR TITLE
cleanup properties now handled by extension

### DIFF
--- a/lib/widgets/breadcrumb/breadcrumb_model.dart
+++ b/lib/widgets/breadcrumb/breadcrumb_model.dart
@@ -30,36 +30,6 @@ class BreadcrumbModel extends DecoratedWidgetModel implements IViewableWidget
   }
   Color? get backgroundcolor => _backgroundcolor?.get();
 
-  /// Opacity
-  DoubleObservable? _opacity;
-  set opacity (dynamic v)
-  {
-    if (_opacity != null)
-    {
-      _opacity!.set(v);
-    }
-    else if (v != null)
-    {
-      _opacity = DoubleObservable(Binding.toKey(id, 'opacity'), v, scope: scope, listener: onPropertyChange);
-    }
-  }
-  double? get opacity => _opacity?.get();
-
-  /// Width of the breadcrumbs and bar
-  DoubleObservable? _width;
-  set width (dynamic v)
-  {
-    if (_width != null)
-    {
-      _width!.set(v);
-    }
-    else if (v != null)
-    {
-      _width = DoubleObservable(Binding.toKey(id, 'width'), v, scope: scope, listener: onPropertyChange);
-    }
-  }
-  double? get width => _width?.get();
-
   BreadcrumbModel({
     WidgetModel? parent,
     String? id,

--- a/lib/widgets/icon/icon_model.dart
+++ b/lib/widgets/icon/icon_model.dart
@@ -102,23 +102,6 @@ class IconModel extends DecoratedWidgetModel implements IViewableWidget
   }
   double get rotation => _rotation?.get() ?? 0.0;
 
-  /////////////
-  /* opacity */
-  /////////////
-  DoubleObservable? _opacity;
-  set opacity (dynamic v)
-  {
-    if (_opacity != null)
-    {
-      _opacity!.set(v);
-    }
-    else if (v != null)
-    {
-      _opacity = DoubleObservable(Binding.toKey(id, 'opacity'), v, scope: scope, listener: onPropertyChange);
-    }
-  }
-  double? get opacity => _opacity?.get();
-
   IconModel(
     WidgetModel? parent,
     String?  id,

--- a/lib/widgets/image/image_model.dart
+++ b/lib/widgets/image/image_model.dart
@@ -63,23 +63,6 @@ class ImageModel extends DecoratedWidgetModel implements IViewableWidget
   }
   double? get rotation => _rotation?.get();
 
-  /////////////
-  /* opacity */
-  /////////////
-  DoubleObservable? _opacity;
-  set opacity (dynamic v)
-  {
-    if (_opacity != null)
-    {
-      _opacity!.set(v);
-    }
-    else if (v != null)
-    {
-      _opacity = DoubleObservable(Binding.toKey(id, 'opacity'), v, scope: scope, listener: onPropertyChange);
-    }
-  }
-  double? get opacity => _opacity?.get();
-
   /////////
   /* fit */
   /////////


### PR DESCRIPTION
DecoratedWidget and ViewableWidget are inherited by these widgets and provide the attribute observables I've removed because they we're not overrides.