### PR TITLE
INPUT password error text typo/clarity

### DIFF
--- a/lib/widgets/input/input_view.dart
+++ b/lib/widgets/input/input_view.dart
@@ -408,7 +408,7 @@ class _InputViewState extends WidgetState<InputView> with WidgetsBindingObserver
           hasSetObscure = true;
         }
         keyboardtype = "password";
-        overrideErrorText = "The password must be a minumum of 8 characters, including 1 upper and 1 lowercase.";
+        overrideErrorText = "The password must be at least 8 characters long, including upper/lowercase and a number.";
         validator = TextInputValidators().isPasswordValid;
         break;
 


### PR DESCRIPTION
# New Pull Request

## Description
Improve the input error text for password fields

### Type of Request:
- [x] Bug Fix.
- [ ] New Feature.
- [x] Improved Feature.
- [ ] Breaking Change.
- [ ] Refactoring.

### Describe your changes for the release notes in bullet form:
- Error text change

### Describe any change in functionality/use to the user, including deprecations:
- n/a

### List ALL potentially Affected Widgets/Events/Evals/Systems (or inheritance):
- INPUT / layouts with password fields, the new error description is slightly longer.

### Describe the test configurations you preformed:
- n/a

## Checklist

### Checklist before requesting a review:
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code as if explaining it to someone new.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces it may affect in both FMLPAD and my own test.
- [x] I have submitted a PR to the documentation to reflect these changes.
- [x] I have attached an example update for FMLPAD for any examples that will be affected by my change.
- [x] I have attached a test template with comments that highlights some of my main changes.




