### PR TITLE
http broker execute caller by method name

### DIFF
--- a/lib/datasources/http/delete/model.dart
+++ b/lib/datasources/http/delete/model.dart
@@ -35,4 +35,18 @@ class HttpDeleteModel extends HttpModel implements IDataSource
   void deserialize(XmlElement xml)
   {    super.deserialize(xml);
   }
+
+  @override
+  Future<bool?> execute(String caller, String propertyOrFunction, List<dynamic> arguments) async
+  {
+    if (scope == null) return null;
+    var function = propertyOrFunction.toLowerCase().trim();
+
+    bool refresh = S.toBool(S.item(arguments,0)) ?? false;
+    switch (function)
+    {
+      case "delete" : return await start(refresh: refresh);
+    }
+    return super.execute(caller, propertyOrFunction, arguments);
+  }
 }

--- a/lib/datasources/http/get/model.dart
+++ b/lib/datasources/http/get/model.dart
@@ -38,4 +38,18 @@ class HttpGetModel extends HttpModel implements IDataSource
   void deserialize(XmlElement xml)
   {    super.deserialize(xml);
   }
+
+  @override
+  Future<bool?> execute(String caller, String propertyOrFunction, List<dynamic> arguments) async
+  {
+    if (scope == null) return null;
+    var function = propertyOrFunction.toLowerCase().trim();
+
+    bool refresh = S.toBool(S.item(arguments,0)) ?? false;
+    switch (function)
+    {
+      case "get" : return await start(refresh: refresh);
+    }
+    return super.execute(caller, propertyOrFunction, arguments);
+  }
 }

--- a/lib/datasources/http/patch/model.dart
+++ b/lib/datasources/http/patch/model.dart
@@ -35,4 +35,18 @@ class HttpPatchModel extends HttpModel implements IDataSource
   void deserialize(XmlElement xml)
   {    super.deserialize(xml);
   }
+
+  @override
+  Future<bool?> execute(String caller, String propertyOrFunction, List<dynamic> arguments) async
+  {
+    if (scope == null) return null;
+    var function = propertyOrFunction.toLowerCase().trim();
+
+    bool refresh = S.toBool(S.item(arguments,0)) ?? false;
+    switch (function)
+    {
+      case "patch" : return await start(refresh: refresh);
+    }
+    return super.execute(caller, propertyOrFunction, arguments);
+  }
 }

--- a/lib/datasources/http/post/model.dart
+++ b/lib/datasources/http/post/model.dart
@@ -35,4 +35,18 @@ class HttpPostModel extends HttpModel implements IDataSource
   void deserialize(XmlElement xml)
   {    super.deserialize(xml);
   }
+
+  @override
+  Future<bool?> execute(String caller, String propertyOrFunction, List<dynamic> arguments) async
+  {
+    if (scope == null) return null;
+    var function = propertyOrFunction.toLowerCase().trim();
+
+    bool refresh = S.toBool(S.item(arguments,0)) ?? false;
+    switch (function)
+    {
+      case "post" : return await start(refresh: refresh);
+    }
+    return super.execute(caller, propertyOrFunction, arguments);
+  }
 }

--- a/lib/datasources/http/put/model.dart
+++ b/lib/datasources/http/put/model.dart
@@ -35,4 +35,18 @@ class HttpPutModel extends HttpModel implements IDataSource
   void deserialize(XmlElement xml)
   {    super.deserialize(xml);
   }
+
+  @override
+  Future<bool?> execute(String caller, String propertyOrFunction, List<dynamic> arguments) async
+  {
+    if (scope == null) return null;
+    var function = propertyOrFunction.toLowerCase().trim();
+
+    bool refresh = S.toBool(S.item(arguments,0)) ?? false;
+    switch (function)
+    {
+      case "put" : return await start(refresh: refresh);
+    }
+    return super.execute(caller, propertyOrFunction, arguments);
+  }
 }


### PR DESCRIPTION
## Description

- Allows a DELETE to be called by id.delete()
- Allows a GET to be called by id.get()
- Allows a PATCH to be called by id.patch()
- Allows a POST to be called by id.post()
- Allows a PUT to be called by id.put()

### Type of Request and links to any relevate issues or PRs (remove any unrelevant types):
- [**Improved Feature**]
- [**Refactoring**]


### Describe your changes for the release notes in bullet form:
- http datasources can now be executed with their method type name, ie a GET datasource can be executed with id.get()


### Describe any change in functionality/use to the user, including deprecations:
- no changes or deprecations


### List ALL potentially Affected Widgets/Events/Evals/Systems/Platforms:
- n/a


### Describe the test configurations you preformed and on what platform(s):
- 


### Test template with comments for reviewer (remove if not applicable):
Paste a complete test template within the xml markdown and if applicable write here how to effectively reproduce your test.

<details>
<summary> Show Example FML Template </summary>
    
```xml
<FML>
    <GET id="db" url="https://google.ca" />
    <BUTTON label="google" onclick="db.get()" />
</FML>
```

</details>  


## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces and all platforms it may affect.
- [x] I have attached a test template with comments that highlights some of my main changes.
- [x] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


