### PR TITLE
log datetime fix (24hr)

### DIFF
--- a/lib/hive/log.dart
+++ b/lib/hive/log.dart
@@ -27,7 +27,7 @@ class Log
     _map["key"]     = key ?? S.newId();
     _map["type"]    = type    ?? "error";
     _map["epoch"]   = epoch   ?? DateTime.now().millisecondsSinceEpoch;
-    _map["date"]    = DateFormat("yyyy-MM-dd hh:mm:ss.sss").format(DateTime.fromMillisecondsSinceEpoch(this.epoch));
+    _map["date"]    = DateFormat("yyyy-MM-dd HH:mm:ss.sss").format(DateTime.fromMillisecondsSinceEpoch(this.epoch));
     _map["message"] = message ?? "";
     _map["caller"]  = caller;
   }


### PR DESCRIPTION
## Description
- Log time wasn't 24 hour from hive

### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Bug Fix**]


### Describe your changes for the release notes in bullet form:
- Fix log bug, now records time in 24h


### Describe any change in functionality/use to the user, including deprecations:
- n/a


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- LOG datasource


### Describe the test configurations you preformed and on what platform(s):
- Ensured log timestamps between 1:00pm and 12:59am are in 24 hr format (13:00-00:59)


## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [ ] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [ ] I have tested the changes on any pieces and all platforms it may affect.
- [ ] I have attached a test template with comments that highlights some of my main changes.
- [ ] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


