### PR TITLE
typeahead scrollbar fix and input hint color

### DIFF
--- a/lib/widgets/form/decorated_input_model.dart
+++ b/lib/widgets/form/decorated_input_model.dart
@@ -319,7 +319,7 @@ class DecoratedInputModel extends FormFieldModel {
   }
 
   //set the field color based on the error state
-  Color setErrorHintColor(BuildContext context) {
+  Color setErrorHintColor(BuildContext context, {Color? color}) {
     if (enabled != false) {
       if(returnErrorState()) {
         return Theme.of(context).colorScheme.error;
@@ -327,7 +327,7 @@ class DecoratedInputModel extends FormFieldModel {
         return color ?? Theme
             .of(context)
             .colorScheme
-            .surfaceVariant;
+            .onSurfaceVariant;
       }
     } else {
       return color ?? Theme.of(context).colorScheme.primary.withOpacity(0.5);

--- a/lib/widgets/input/input_view.dart
+++ b/lib/widgets/input/input_view.dart
@@ -627,7 +627,7 @@ class _InputViewState extends WidgetState<InputView>
     // set the text color arrays
     Color? enabledTextColor = widget.model.textcolor;
     Color? disabledTextColor = Theme.of(context).disabledColor;
-    Color? hintTextColor =Theme.of(context).focusColor;
+    Color? hintTextColor = widget.model.textcolor?.withOpacity(0.7) ?? Theme.of(context).focusColor;
     Color? errorTextColor = Theme.of(context).colorScheme.error;
 
     double? fontsize = widget.model.size;
@@ -704,7 +704,24 @@ class _InputViewState extends WidgetState<InputView>
           labelText: widget.model.dense ? null : hint,
           labelStyle: TextStyle(
             fontSize: fontsize != null ? fontsize - 2 : 14,
-            color: widget.model.setErrorHintColor(context),
+            color: widget.model.setErrorHintColor(context, color: hintTextColor),
+            shadows: <Shadow>[
+              Shadow(
+                offset: Offset(0.0, 0.5),
+                blurRadius: 2.0,
+                color: widget.model.color ?? Colors.transparent
+              ),
+              Shadow(
+                  offset: Offset(0.0, 0.5),
+                  blurRadius: 2.0,
+                  color: widget.model.color ?? Colors.transparent
+              ),
+              Shadow(
+                  offset: Offset(0.0, 0.5),
+                  blurRadius: 2.0,
+                  color: widget.model.color ?? Colors.transparent
+              ),
+            ],
           ),
           errorStyle: TextStyle(
             fontSize: fontsize ?? 14,
@@ -716,7 +733,7 @@ class _InputViewState extends WidgetState<InputView>
           hintStyle: TextStyle(
             fontSize: fontsize ?? 14,
             fontWeight: FontWeight.w300,
-            color: widget.model.setErrorHintColor(context),
+            color: widget.model.setErrorHintColor(context, color: hintTextColor),
           ),
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,7 +107,7 @@ dependencies:
   # MIT
 
   # Updated 2023/01/30
-  flutter_typeahead: ^4.6.0
+  flutter_typeahead: ^4.6.1
   # BSD-2-Clause
 
   # Updated 2022/12/30


### PR DESCRIPTION
## Description
Fixed the typeahead package so now the mouse click doesn't go through the scrollbar and close it.
Fixed the hint color on input to not be the same as the background

### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Bug Fix**]
- [**New Feature**]

### Describe your changes for the release notes in bullet form:
- Typeahead bugfix for scrollbar clickthrough


### Describe any change in functionality/use to the user, including deprecations:
- n/a


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- Typeahead / Input


### Describe the test configurations you preformed and on what platform(s):
- windwows/web testing mouse click through



## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces and all platforms it may affect.
- [x] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


