### PR TITLE
Added a binding to the parent value on Alarm. So {this} or {this.valu…

### DIFF
--- a/lib/widgets/alarm/alarm_model.dart
+++ b/lib/widgets/alarm/alarm_model.dart
@@ -10,15 +10,6 @@ class AlarmModel extends WidgetModel
 {
   /// The value of the alarms parent.
   StringObservable? _value;
-  set value(dynamic v) {
-    if (_value != null) {
-      _value?.set(v);
-    } else if (v != null) {
-      _value = StringObservable(Binding.toKey(id, 'value'), v,
-          scope: scope, listener: onPropertyChange);
-    }
-  }
-  String? get value => _value?.get();
 
   /// The error message value of a form field.
   StringObservable? _errortext;
@@ -89,20 +80,23 @@ class AlarmModel extends WidgetModel
   AlarmModel(
       WidgetModel parent,
       String?  id, {
-      dynamic value,
       dynamic error,
       dynamic errortext,
       dynamic onalarm,
       dynamic ondismissed,
       dynamic alarmtrigger,
   })
-      : super(parent, id) {
-    if (value     != null) this.value = value;
-    if (error     != null) this.error = error;
-    if (errortext     != null) this.errortext = errortext;
-    if (onalarm     != null) this.onalarm = onalarm;
-    if (ondismissed     != null) this.ondismissed = ondismissed;
-    if (alarmtrigger     != null) this.alarmtrigger = alarmtrigger;
+      : super(parent, id)
+  {
+    if (error != null) this.error = error;
+    if (errortext != null) this.errortext = errortext;
+    if (onalarm != null) this.onalarm = onalarm;
+    if (ondismissed != null) this.ondismissed = ondismissed;
+    if (alarmtrigger != null) this.alarmtrigger = alarmtrigger;
+
+    // Build a binding to the parent value
+    var binding = "{${parent.id}.value}";
+    _value = StringObservable(Binding.toKey(id, 'value'),binding, scope: scope);
   }
 
   static AlarmModel? fromXml(WidgetModel parent, XmlElement xml)
@@ -110,7 +104,7 @@ class AlarmModel extends WidgetModel
     AlarmModel? model;
     try
     {
-      model = AlarmModel(parent, Xml.get(node: xml, tag: 'id'), value: Xml.getText(xml));
+      model = AlarmModel(parent, Xml.get(node: xml, tag: 'id'));
       model.deserialize(xml);
     }
     catch(e)

--- a/lib/widgets/form/form_field_model.dart
+++ b/lib/widgets/form/form_field_model.dart
@@ -307,11 +307,13 @@ class FormFieldModel extends DecoratedWidgetModel {
     onchange = Xml.get(node: xml, tag: 'onchange');
 
     // Build alarms
-    List<AlarmModel> alarms =
-        findChildrenOfExactType(AlarmModel).cast<AlarmModel>();
+    List<AlarmModel> alarms = findChildrenOfExactType(AlarmModel).cast<AlarmModel>();
+
     _alarms.clear();
-    for (var alarm in alarms) {
+    for (var alarm in alarms)
+    {
       _alarms[alarm.id] = alarm;
+
       //register a listener to always throw the alarm state when the value of the alarm changes if the alarm type is 'all'
       alarm.seterror?.registerListener(onAlarmChange);
     }


### PR DESCRIPTION
…e} on alarm refers to the parent value

## Description
The ability to use the this keyword on the alarm to refer to the parents value, which in turn is the alarms value.

### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Improved Feature**]



### Describe your changes for the release notes in bullet form:
- The value of the alarm is the observed value of the parent.



### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- ALARM


### Test template with comments for reviewer (remove if not applicable):
Paste a complete test template within the xml markdown and if applicable write here how to effectively reproduce your test.

<details>
<summary> Show Example FML Template </summary>
    
```xml
			<SELECT id="select2">

				<ALARM id="almno" error="={this}=='no'" errortext="This field is no"/>
				<ALARM id="almyes" error="={this}=='yes'" errortext="This field is yes"/>
				<OPTION value="yes"/>
				<OPTION value="no"/>
				<OPTION value="clear"/>
			</SELECT> 
```

</details>  


## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces and all platforms it may affect.
- [x] I have attached a test template with comments that highlights some of my main changes.
- [x] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


