### PR TITLE
Fix to Resize Stack when Children Size Chanages

### DIFF
--- a/lib/widgets/box/stack_renderer.dart
+++ b/lib/widgets/box/stack_renderer.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:fml/widgets/box/box_constraints.dart';
 import 'package:fml/widgets/box/box_data.dart';
 import 'package:fml/widgets/box/box_mixin.dart';
 import 'package:fml/widgets/box/box_model.dart';
@@ -221,7 +222,11 @@ class StackRenderer extends RenderBox with
       childConstraints = childConstraints.tighten(height: childParentData.height);
     }
 
-    child.layout(childConstraints, parentUsesSize: true);
+    // calculate the child's size by performing
+    // a dry layout. We use LocalBoxConstraints in order to
+    // override isTight, which is used in Layout() to determine if a
+    // child size change forces a parent to resize.
+    child.layout(LocalBoxConstraints.from(childConstraints), parentUsesSize: true);
 
     final double x;
     if (childParentData.left != null) {
@@ -306,8 +311,11 @@ class StackRenderer extends RenderBox with
         var childConstraints = myConstraints;
         if (childData.model != null) childConstraints = getChildLayoutConstraints(constraints, child, childData.model!);
 
-        // layout the child
-        layoutChild(child, childConstraints);
+        // calculate the child's size by performing
+        // a dry layout. We use LocalBoxConstraints in order to
+        // override isTight, which is used in Layout() to determine if a
+        // child size change forces a parent to resize.
+        layoutChild(child, LocalBoxConstraints.from(childConstraints));
 
         // size of stack is largest unpositioned child if not hard sized
         if (!hardSizedWidth)  width  = math.max(width,  child.size.width);


### PR DESCRIPTION
## Description


### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Bug Fix**]

### Describe your changes for the release notes in bullet form:
- New Stack Renderer didn't resize when child changed size.


### Describe any change in functionality/use to the user, including deprecations:
- Stack Resizing now works as expected


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- BOX layout="stack"


### Describe the test configurations you preformed and on what platform(s):
- 


### Test template with comments for reviewer (remove if not applicable):
Paste a complete test template within the xml markdown and if applicable write here how to effectively reproduce your test.

<FML color="white" layout="col" center="true">


          <VAR id="userlistitem" value="false"/>
          <!--THIS WORKS IN EVERY CASE BUT LAYOUT=STACK-->
          <BOX width="90" height="90" layout="stack" center="true" color="red">
						<BOX width="={userlistitem} ? 80 : 50" height="={userlistitem} ?  80 : 50" color="blue"/>
					</BOX>

          <BUTTON label="size change" onclick="userlistitem.set(!{userlistitem})"/>

</FML>

## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces and all platforms it may affect.
- [x] I have attached a test template with comments that highlights some of my main changes.
- [x] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


