### PR TITLE
fix for broken color emojis 😞 in flutter 3.10 (web only)

### DIFF
--- a/lib/system.dart
+++ b/lib/system.dart
@@ -37,7 +37,7 @@ final String applicationTitle = "Flutter Markup Language $version";
 // Used in SingleApp only and on Web when developing on localhost
 // Set this to file://applications/<app> to use the asset applications
 
-String get defaultDomain => 'http://fml.appdaddy.co';
+String get defaultDomain => 'https://pad.fml.dev';
 
 // SingleApp - App initializes from a single domain endpoint (defined in defaultDomain)
 // MultiApp  - (Desktop & Mobile Only) Launches the Store at startup

--- a/web/index.html
+++ b/web/index.html
@@ -137,13 +137,12 @@
                 onEntrypointLoaded: async function(engineInitializer)
                 {
                     // if (loadingText != null) loadingText.textContent = "Initializing engine...";
-                    let config = {renderer: renderer}
+                    let config = { renderer: renderer, useColorEmoji: true }
                     let appRunner = await engineInitializer.initializeEngine(config)
 
                     // remove loading image and text
                     if (loadingImage != null) loadingImage.remove();
                     if (loadingText  != null) loadingText.remove();
-
                     // run the app
                     await appRunner.runApp();
                 }


### PR DESCRIPTION
## Description
fix for color emojis broken (😢 ) in flutter 3.10, but only fixes web, desktop platforms may be broken still.

### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Bug Fix**]


### Describe your changes for the release notes in bullet form:
- Emoji fix in web to have color again


### Describe any change in functionality/use to the user, including deprecations:
- n/a


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- web


### Describe the test configurations you preformed and on what platform(s):
- tested on fml pad

## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [x] I have performed a Self-Review and Refactor of my code.
- [x] I have formatted my code to follow project style guidelines.
- [x] I have commented my code with clear and informative descriptions.
- [x] I have compared my code to main and ensured I did not unintentionally remove features.
- [x] I have tested the changes on any pieces and all platforms it may affect.
- [x] I have attached a test template with comments that highlights some of my main changes.
- [x] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


