### PR TITLE
Disable zebra datasource by default when not on top of framework stack

### DIFF
--- a/lib/datasources/base/model.dart
+++ b/lib/datasources/base/model.dart
@@ -21,6 +21,11 @@ enum ListTypes { replace, lifo, fifo, append, prepend }
 
 class DataSourceModel extends ViewableWidgetModel implements IDataSource
 {
+  // allow datasource to continue execution if not
+  // top of stack
+  // override by setting background="false"
+  bool get allowBackgroundExecution => true;
+
   // data override
   @override
   Data? get data
@@ -433,13 +438,8 @@ class DataSourceModel extends ViewableWidgetModel implements IDataSource
     // register the datasource with the scope manager
     if (scope != null) scope!.registerDataSource(this);
 
-    // disable the datasource when the framework isn't active (i.e. top of stack)
-    bool? runInBackground = S.toBool(Xml.get(node: xml, tag: 'background'));
-    if ((runInBackground == false) &&
-        (framework != null) &&
-        (framework!.indexObservable != null)) {
-      framework!.indexObservable!.registerListener(onIndexChange);
-    }
+    bool runInBackground = S.toBool(Xml.get(node: xml, tag: 'background')) ?? allowBackgroundExecution;
+    if (!runInBackground) framework?.indexObservable?.registerListener(onIndexChange);
   }
 
   void onIndexChange(Observable index) {

--- a/lib/datasources/zebra/model.dart
+++ b/lib/datasources/zebra/model.dart
@@ -12,6 +12,11 @@ import 'package:fml/helper/common_helpers.dart';
 
 class ZebraModel extends DataSourceModel implements IDataSource, IZebraListener
 {
+  // disable datasource by default when not top of stack
+  // override by setting background="true"
+  @override
+  bool get allowBackgroundExecution => false;
+
   @override
   bool get autoexecute => super.autoexecute ?? true;
 


### PR DESCRIPTION
## Description


### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Improved Feature**]



### Describe your changes for the release notes in bullet form:
- Zebra devices disable by default when not in focus (current page)


### Describe any change in functionality/use to the user, including deprecations:
- Zebra Data Sources should not work when not current template


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- ZEBRA


### Describe the test configurations you preformed and on what platform(s):
- 


### Test template with comments for reviewer (remove if not applicable):
Paste a complete test template within the xml markdown and if applicable write here how to effectively reproduce your test.

<details>
<summary> Show Example FML Template </summary>
    
```xml
<PASTE_TEST_TEMPLATE_HERE />
```

</details>  


## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [ ] I have performed a Self-Review and Refactor of my code.
- [ ] I have formatted my code to follow project style guidelines.
- [ ] I have commented my code with clear and informative descriptions.
- [ ] I have compared my code to main and ensured I did not unintentionally remove features.
- [ ] I have tested the changes on any pieces and all platforms it may affect.
- [ ] I have attached a test template with comments that highlights some of my main changes.
- [ ] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


