### PR TITLE
Disable zebra datasource by default when not on top of framework stack

### DIFF
--- a/lib/datasources/zebra/model.dart
+++ b/lib/datasources/zebra/model.dart
@@ -15,7 +15,7 @@ class ZebraModel extends DataSourceModel implements IDataSource, IZebraListener
   // disable datasource by default when not top of stack
   // override by setting background="true"
   @override
-  bool get allowBackgroundExecution => false;
+  bool get enabledInBackground => false;
 
   @override
   bool get autoexecute => super.autoexecute ?? true;


### PR DESCRIPTION
## Description


### Type of Request and links to any relevant issues or PRs (remove any irrelevant types):
- [**Bug Fix**]



### Describe your changes for the release notes in bullet form:
- background=true/false allows the data source to run when it is not the current page


### Describe any change in functionality/use to the user, including deprecations:
- 


### List ALL potentially Affected Widgets/Events/Evaluations/Systems/Platforms:
- 


### Describe the test configurations you preformed and on what platform(s):
- 


### Test template with comments for reviewer (remove if not applicable):
Paste a complete test template within the xml markdown and if applicable write here how to effectively reproduce your test.

<details>
<summary> Show Example FML Template </summary>
    
```xml
<PASTE_TEST_TEMPLATE_HERE />
```

</details>  


## Checklist

### Checklist before requesting a review:
- [x] I have created a PR.
- [ ] I have performed a Self-Review and Refactor of my code.
- [ ] I have formatted my code to follow project style guidelines.
- [ ] I have commented my code with clear and informative descriptions.
- [ ] I have compared my code to main and ensured I did not unintentionally remove features.
- [ ] I have tested the changes on any pieces and all platforms it may affect.
- [ ] I have attached a test template with comments that highlights some of my main changes.
- [ ] I have noted all changes that invalidate the wiki documentation or fmlpad and any refactoring required.

Thank you for your effort to improve FML! If you have any other comments please leave them as a separate comment on this PR.  


