### PR TITLE
Added a showIcon attribute to datepicker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,17 +11,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    //String example1 = 'http://10.69.4.245:81/';
-  //`  String example1 = 'https://test.appdaddy.co';
-    //String example1 = 'http://lawapsweb.law.goodyear.com:8081';
-    //String example1 = 'https://pad.fml.dev';
-    //String example1 = "http://10.69.4.149:8081/";
-
-    //String example1 = 'http://ludapsweb.ec.goodyear.com:81/';
-    //String example1 = 'https://fml.dev';
-    //String example2 = 'file://fmlpad';
-    //String example3 = 'file://example';
-    String example1 = 'http://tpkapsweb.tpk.goodyear.com:8081/';
+    String example1 = 'https://test.appdaddy.co';
 
     var version = "3.0.0";
 

--- a/lib/widgets/datepicker/datepicker_model.dart
+++ b/lib/widgets/datepicker/datepicker_model.dart
@@ -35,6 +35,18 @@ class DatepickerModel extends DecoratedInputModel implements IFormField {
   }
   bool? get view => _view?.get();
 
+  // readonly
+  BooleanObservable? _showIcon;
+  set showIcon(dynamic v) {
+    if (_showIcon != null) {
+      _showIcon!.set(v);
+    } else if (v != null) {
+      _showIcon = BooleanObservable(Binding.toKey(id, 'showIcon'), v,
+          scope: scope, listener: onPropertyChange);
+    }
+  }
+
+  bool get showIcon => _showIcon?.get() ?? true;
   /// type of the date picker. Can be "datetime", "date", "time", "range" or "year"
   StringObservable? _type;
   set type(dynamic v) {
@@ -183,10 +195,12 @@ class DatepickerModel extends DecoratedInputModel implements IFormField {
     String? type,
     dynamic format,
     dynamic clear,
+    dynamic showIcon,
   }) {
     if (type != null) this.type = type;
     if (format != null) this.format = format;
     if (clear != null) this.clear = clear;
+    if (showIcon != null) this.showIcon = showIcon;
   }
 
   static DatepickerModel? fromXml(Model parent, XmlElement xml,
@@ -224,6 +238,7 @@ class DatepickerModel extends DecoratedInputModel implements IFormField {
 
     mode   = Xml.get(node: xml, tag: 'mode');
     tmode  = Xml.get(node: xml, tag: 'tmode');
+    showIcon  = Xml.get(node: xml, tag: 'showIcon');
   }
 
   @override

--- a/lib/widgets/datepicker/datepicker_view.dart
+++ b/lib/widgets/datepicker/datepicker_view.dart
@@ -360,13 +360,15 @@ class DatepickerViewState extends ViewableWidgetState<DatepickerView> {
               fontWeight: FontWeight.w300,
               color: widget.model.getErrorHintColor(context),
             ),
-            prefixIcon: Padding(
+            prefixIcon: widget.model.showIcon
+                ? Padding(
                 padding:
                 const EdgeInsets.only(right: 10, left: 10, bottom: 0),
                 child: Icon(widget.model.icon ??
                     (widget.model.type == "time"
                         ? Icons.access_time
-                        : Icons.calendar_today))),
+                        : Icons.calendar_today)))
+                : null,
             prefixIconConstraints: const BoxConstraints(maxHeight: 24),
             border: _getBorder(enabledBorderColor, null),
             errorBorder: _getBorder(errorBorderColor, null),


### PR DESCRIPTION
Allows the user to further customize datepicker by creating a showIcon attribute that when false, hides the icon of the calendar or clock.